### PR TITLE
UP-238: add web-of-trust demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.egg-info
 build
 dist
+/venv3

--- a/README.md
+++ b/README.md
@@ -146,6 +146,55 @@ The script goes through a number of steps:
 4. registers the new identity with the backend
 5. sends two consecutive chained messages to the backend
 
+### Example: Web-of-Trust
+
+#### Before First Execution
+
+```bash
+python3 -m venv venv3
+pip install -r requirements.txt
+pip install ubirch-protocol
+```
+
+#### Running The Example
+
+```bash
+. venv3/bin/activate
+python3 examples/test-web-of-trust.py
+```
+
+During first launch the script generates key pairs for two users. Each user has one device and key pairs are created for 
+these, too. All key pairs are stored in `test-web-of-trust.jks` while the association of users, their device and the 
+respective key pair is stored in `demo-web-of-trust.ini`. In consecutive runs no new key pairs are generated and instead
+the ones referenced in `demo-web-of-trust.ini` are used.
+
+The script always uploads all public keys, followed by creating and uploading a web-of-trust and searching all public 
+keys trusted by `deviceA`. This search is repeated with different parameters. The results are then printed onto the
+terminal.
+
+The web-of-trust created looks as follows (trust knows a direction; always bidirectional in this example):
+
+```
+deviceA <--trustLevel=100--> user1 <--trustLevel=50--> user2 <--trustLevel=100--> deviceB
+```
+
+The first search for all trusted keys is for a minimum trust of 50 and a depth of 3 resulting in the the following keys
+being found:
+
+* user1
+* user2
+* deviceB
+
+The second search increases the minimum trust to 60 resulting in:
+
+* user1
+
+And the third search is with a minimum trust of 50 again while the depth is now 2 resulting in:
+
+* user1
+* user2
+
+
 ### Testing
 
 Unit tests are added to test the functionality of all objects provided in this library.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ sudo apt install python3-pip
 python3 -m venv venv3
 . venv3/bin/activate
 pip install -r requirements.txt
-pip3 install ubirch-protocol
+pip install ubirch-protocol
 python3 examples/test-protocol.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,14 +125,6 @@ keystore.insert_ed25519_keypair(hwDeviceId, vk, sk)
 
 ### Running the example
 
-#### Setting Up The Environment (Ubuntu 16.04)
-
-```bash
-sudo apt install python3-pip
-```
-
-#### Running the Test Script
-
 ```bash
 python3 -m venv venv3
 . venv3/bin/activate

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ sudo apt install python3-pip
 
 ```bash
 python3 -m venv venv3
-pip3 install -r requirements.txt
+. venv3/bin/activate
+pip install -r requirements.txt
 pip3 install ubirch-protocol
 python3 examples/test-protocol.py
 ```

--- a/README.md
+++ b/README.md
@@ -125,9 +125,18 @@ keystore.insert_ed25519_keypair(hwDeviceId, vk, sk)
 
 ### Running the example
 
+#### Setting Up The Environment (Ubuntu 16.04)
+
+```bash
+sudo apt install python3-pip
+```
+
+#### Running the Test Script
+
 ```bash
 python3 -m venv venv3
-pip install -r requirements.txt
+pip3 install -r requirements.txt
+pip3 install ubirch-protocol
 python3 examples/test-protocol.py
 ```
 

--- a/examples/test-web-of-trust.py
+++ b/examples/test-web-of-trust.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2018 ubirch GmbH.
 #
-# @author Matthias L. Jugel
+# @author Christian Vandrei
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 # limitations under the License.
 
 import base64
+import configparser
 import json
 import logging
-import os
-from uuid import UUID
+import requests
+from datetime import datetime
+from uuid import UUID, uuid4
 
 import ubirch
 from ubirch.ubirch_protocol import UBIRCH_PROTOCOL_TYPE_REG
@@ -29,40 +31,184 @@ logging.basicConfig(format='%(asctime)s %(name)20.20s %(levelname)-8.8s %(messag
 logger = logging.getLogger()
 
 
+########################################################################
+# Implement the ubirch-protocol with signing and saving the signatures
 class Proto(ubirch.Protocol):
-    def __init__(self, key_store: ubirch.KeyStore) -> None:
+
+    def __init__(self, key_store: ubirch.KeyStore, uuid: UUID) -> None:
         super().__init__()
         self.__ks = key_store
+        self.load(uuid)
+        logger.info("ubirch-protocol: device id: {}".format(uuid))
+
+    def persist(self, uuid: UUID):
+        signatures = self.get_saved_signatures()
+        with open(uuid.hex + ".sig", "wb") as f:
+            pickle.dump(signatures, f)
+
+    def load(self, uuid: UUID):
+        try:
+            with open(uuid.hex + ".sig", "rb") as f:
+                signatures = pickle.load(f)
+                logger.info("loaded {} known signatures".format(len(signatures)))
+                self.set_saved_signatures(signatures)
+        except:
+            logger.warning("no existing saved signatures")
+            pass
 
     def _sign(self, uuid: UUID, message: bytes) -> bytes:
         return self.__ks.find_signing_key(uuid).sign(message)
 
 
-uuid = UUID(hex=os.getenv("UBIRCH_UUID"))
-auth = os.getenv("UBIRCH_AUTH")
-env = os.getenv("UBIRCH_ENV")
+########################################################################
 
-logger.info("UUID : {}".format(uuid))
-logger.info("AUTH : {}".format(auth))
+# load configuration from storage
+config_file = 'demo-web-of-trust.ini'
+config = configparser.ConfigParser()
+config.read(config_file)
+if not config.has_section('misc'):
+    config.add_section('misc')
+    config.set('misc', 'env', 'demo')
+    with open(config_file, "w") as f:
+        config.write(f)
+if not config.has_section('user1'):
+    config.add_section('user1')
+    config.set('user1', 'uuid', str(uuid4()))
+    config.set('user1', 'deviceA', str(uuid4()))
+    with open(config_file, "w") as f:
+        config.write(f)
+if not config.has_section('user2'):
+    config.add_section('user2')
+    config.set('user2', 'uuid', str(uuid4()))
+    config.set('user2', 'deviceB', str(uuid4()))
+    with open(config_file, "w") as f:
+        config.write(f)
+
+env = config.get('misc', 'env', fallback=None)
+auth = None
+user1_uuid = UUID(hex=config.get('user1', 'uuid'))
+user1_deviceA = UUID(hex=config.get('user1', 'deviceA'))
+user2_uuid = UUID(hex=config.get('user2', 'uuid'))
+user2_deviceB = UUID(hex=config.get('user2', 'deviceB'))
+
+logger.info("UUID (user1) : {}".format(user1_uuid))
+logger.info("UUID (user1.deviceA) : {}".format(user1_deviceA))
+logger.info("UUID (user2) : {}".format(user2_uuid))
+logger.info("UUID (user2.deviceB) : {}".format(user2_deviceB))
 logger.info("ENV  : {}".format(env))
 
-keystore = ubirch.KeyStore("test-identity.jks", "test-keystore")
-proto = Proto(keystore)
+keystore = ubirch.KeyStore("test-web-of-trust.jks", "test-keystore")
 
-if not keystore.exists_signing_key(uuid):
-    keystore.create_ed25519_keypair(uuid)
+if not keystore.exists_signing_key(user1_uuid):
+    keystore.create_ed25519_keypair(user1_uuid)
+if not keystore.exists_signing_key(user1_deviceA):
+    keystore.create_ed25519_keypair(user1_deviceA)
+if not keystore.exists_signing_key(user2_uuid):
+    keystore.create_ed25519_keypair(user2_uuid)
+if not keystore.exists_signing_key(user2_deviceB):
+    keystore.create_ed25519_keypair(user2_deviceB)
 
-sk = keystore.find_signing_key(uuid)
-vk = keystore.find_verifying_key(uuid)
-
-# create API and de-register the key
 api = ubirch.API(auth=auth, env=env)
-key_registration = proto.message_signed(uuid, UBIRCH_PROTOCOL_TYPE_REG, keystore.get_certificate(uuid))
-r = api.register_identity(key_registration)
-logger.info("registered: {}: {}".format(r.status_code, r.content))
-key_deregistration = str.encode(json.dumps({
-    "publicKey": bytes.decode(base64.b64encode(vk.to_bytes())),
-    "signature": bytes.decode(base64.b64encode(sk.sign(vk.to_bytes())))
-}))
-r = api.deregister_identity(key_deregistration)
-logger.info("registered: {}: {}".format(r.status_code, r.content))
+
+
+def upload_public_key(uuid: UUID, info_text: str):
+    proto = Proto(keystore, uuid)
+    if not api.is_identity_registered(uuid):
+        registration_message = proto.message_signed(uuid, UBIRCH_PROTOCOL_TYPE_REG, keystore.get_certificate(uuid))
+        r = api.register_identity(registration_message)
+        if r.status_code == requests.codes.ok:
+            logger.info(
+                "public key upload successful: '{}' ({}): {}: {}".format(info_text, uuid, r.status_code, r.content))
+        else:
+            logger.info("register of '{}' ({}) failed: {}: {}".format(info_text, uuid, r.status_code, r.content))
+        logger.debug(r.content)
+    else:
+        logger.info("already registered '{}' ({})".format(info_text, uuid))
+
+
+def trust_key(from_uuid: UUID, to_uuid: UUID, trust_level=50):
+    from_private_key = keystore.find_signing_key(from_uuid)
+    from_public_key = keystore.find_verifying_key(from_uuid)
+    from_public_key_base64 = base64.b64encode(from_public_key.to_bytes())
+
+    to_public_key = keystore.find_verifying_key(to_uuid)
+    to_public_key_base64 = base64.b64encode(to_public_key.to_bytes())
+
+    trust_relation = {
+        "created": "{}Z".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3]),
+        "sourcePublicKey": str(bytes.decode(from_public_key_base64)),
+        "targetPublicKey": str(bytes.decode(to_public_key_base64)),
+        "trustLevel": trust_level
+    }
+    compressed_json = json.dumps(trust_relation, separators=(',', ':'), sort_keys=True)
+    signature = from_private_key.sign(str.encode(compressed_json))
+    signed_trust = {
+        "trustRelation": trust_relation,
+        "signature": bytes.decode(base64.b64encode(signature))
+    }
+
+    r = api.trust_identity_json(signed_trust)
+    if r.status_code == requests.codes.ok:
+        logger.info("uploaded trust: {} --{}--> {}".format(from_uuid, trust_level, to_uuid))
+    else:
+        logger.error(
+            "failed to upload trust: {} --{}--> {} ({} {})".format(from_uuid, trust_level, to_uuid, r.status_code,
+                                                                   r.content))
+
+
+def get_trusted(source_public_key: UUID, depth=3, min_trust_level=50) -> requests.Response:
+    private_key = keystore.find_signing_key(source_public_key)
+    public_key = keystore.find_verifying_key(source_public_key)
+    public_key_base64 = base64.b64encode(public_key.to_bytes())
+
+    find_trusted = {
+        "depth": depth,
+        "minTrustLevel": min_trust_level,
+        "queryDate": "{}Z".format(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3]),
+        "sourcePublicKey": str(bytes.decode(public_key_base64))
+    }
+    compressed_json = json.dumps(find_trusted, separators=(',', ':'), sort_keys=True)
+    signature = private_key.sign(str.encode(compressed_json))
+    signed_find_trusted = {
+        "findTrusted": find_trusted,
+        "signature": bytes.decode(base64.b64encode(signature))
+    }
+
+    r = api.get_trusted_identities_json(signed_find_trusted)
+    if r.status_code == requests.codes.ok:
+        logger.info(
+            "found trusted: {} (depth={}, min_trust_level={}) -> {}".format(source_public_key, depth, min_trust_level,
+                                                                            r.content))
+        return r.content
+    else:
+        logger.error(
+            "failed to find trusted: {} (depth={}, min_trust_level={}) ({} {})".format(source_public_key, depth,
+                                                                                       min_trust_level, r.status_code,
+                                                                                       r.content))
+        return r.content
+
+
+# upload public keys
+upload_public_key(user1_uuid, "user1")
+upload_public_key(user1_deviceA, "user1-deviceA")
+upload_public_key(user2_uuid, "user2")
+upload_public_key(user2_deviceB, "user2-deviceB")
+
+# create web-of-trust
+trust_key(user1_uuid, user1_deviceA, 100)
+trust_key(user1_deviceA, user1_uuid, 100)
+
+trust_key(user2_uuid, user2_deviceB, 100)
+trust_key(user2_deviceB, user2_uuid, 100)
+
+trust_key(user1_uuid, user2_uuid)
+trust_key(user2_uuid, user1_uuid)
+
+# search for trusted keys
+source_key = user1_deviceA
+logger.info("====== Find Trusted Keys: depth={}, minimum_trust={}".format(3, 50))
+get_trusted(source_key)
+logger.info("====== Find Trusted Keys: depth={}, minimum_trust={}".format(3, 60))
+get_trusted(source_key, min_trust_level=60)
+logger.info("====== Find Trusted Keys: depth={}, minimum_trust={}".format(2, 50))
+get_trusted(source_key, depth=2)

--- a/examples/test-web-of-trust.py
+++ b/examples/test-web-of-trust.py
@@ -1,0 +1,68 @@
+#! /usr/bin/env python3
+#
+# Copyright (c) 2018 ubirch GmbH.
+#
+# @author Matthias L. Jugel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+import logging
+import os
+from uuid import UUID
+
+import ubirch
+from ubirch.ubirch_protocol import UBIRCH_PROTOCOL_TYPE_REG
+
+logging.basicConfig(format='%(asctime)s %(name)20.20s %(levelname)-8.8s %(message)s', level=logging.DEBUG)
+logger = logging.getLogger()
+
+
+class Proto(ubirch.Protocol):
+    def __init__(self, key_store: ubirch.KeyStore) -> None:
+        super().__init__()
+        self.__ks = key_store
+
+    def _sign(self, uuid: UUID, message: bytes) -> bytes:
+        return self.__ks.find_signing_key(uuid).sign(message)
+
+
+uuid = UUID(hex=os.getenv("UBIRCH_UUID"))
+auth = os.getenv("UBIRCH_AUTH")
+env = os.getenv("UBIRCH_ENV")
+
+logger.info("UUID : {}".format(uuid))
+logger.info("AUTH : {}".format(auth))
+logger.info("ENV  : {}".format(env))
+
+keystore = ubirch.KeyStore("test-identity.jks", "test-keystore")
+proto = Proto(keystore)
+
+if not keystore.exists_signing_key(uuid):
+    keystore.create_ed25519_keypair(uuid)
+
+sk = keystore.find_signing_key(uuid)
+vk = keystore.find_verifying_key(uuid)
+
+# create API and de-register the key
+api = ubirch.API(auth=auth, env=env)
+key_registration = proto.message_signed(uuid, UBIRCH_PROTOCOL_TYPE_REG, keystore.get_certificate(uuid))
+r = api.register_identity(key_registration)
+logger.info("registered: {}: {}".format(r.status_code, r.content))
+key_deregistration = str.encode(json.dumps({
+    "publicKey": bytes.decode(base64.b64encode(vk.to_bytes())),
+    "signature": bytes.decode(base64.b64encode(sk.sign(vk.to_bytes())))
+}))
+r = api.deregister_identity(key_deregistration)
+logger.info("registered: {}: {}".format(r.status_code, r.content))

--- a/ubirch/ubirch_api.py
+++ b/ubirch/ubirch_api.py
@@ -119,17 +119,15 @@ class API(object):
         logger.debug("{}: {}".format(r.status_code, r.content))
         return r
 
-    def _trust_identity_json(self, signed_trust: dict) -> Response:
+    def trust_identity_json(self, signed_trust: dict) -> Response:
         logger.debug("trust an identity [json]: {}".format(signed_trust))
-        r = requests.post(self.get_url(KEY_SERVICE) + '/pubkey/trust', json=signed_trust,
-                          headers=self._auth)
+        r = requests.post(self.get_url(KEY_SERVICE) + '/pubkey/trust', json=signed_trust)
         logger.debug("{}: {}".format(r.status_code, r.content))
         return r
 
-    def _get_trusted_identities_json(self, get_trusted: dict) -> Response:
-        logger.debug("trust an identity [json]: {}".format(get_trusted))
-        r = requests.get(self.get_url(KEY_SERVICE) + '/pubkey/trusted', json=get_trusted,
-                          headers=self._auth)
+    def get_trusted_identities_json(self, get_trusted: dict) -> Response:
+        logger.debug("get trusted identities [json]: {}".format(get_trusted))
+        r = requests.get(self.get_url(KEY_SERVICE) + '/pubkey/trusted', json=get_trusted)
         logger.debug("{}: {}".format(r.status_code, r.content))
         return r
 

--- a/ubirch/ubirch_api.py
+++ b/ubirch/ubirch_api.py
@@ -105,22 +105,36 @@ class API(object):
             return self._deregister_identity_mpack(key_deregistration)
 
     def _register_identity_json(self, key_registration: dict) -> Response:
-        logger.debug("register device identity [json]: {}".format(key_registration))
+        logger.debug("register identity [json]: {}".format(key_registration))
         r = requests.post(self.get_url(KEY_SERVICE) + '/pubkey', json=key_registration,
                           headers=self._auth)
         logger.debug("{}: {}".format(r.status_code, r.content))
         return r
 
     def _register_identity_mpack(self, key_registration: bytes) -> Response:
-        logger.debug("register device identity [msgpack]: {}".format(binascii.hexlify(key_registration)))
+        logger.debug("register identity [msgpack]: {}".format(binascii.hexlify(key_registration)))
         headers = {'Content-Type': 'application/octet-stream'}
         headers.update(self._auth)
         r = requests.post(self.get_url(KEY_SERVICE) + '/pubkey/mpack', data=key_registration, headers=headers)
         logger.debug("{}: {}".format(r.status_code, r.content))
         return r
 
+    def _trust_identity_json(self, signed_trust: dict) -> Response:
+        logger.debug("trust an identity [json]: {}".format(signed_trust))
+        r = requests.post(self.get_url(KEY_SERVICE) + '/pubkey/trust', json=signed_trust,
+                          headers=self._auth)
+        logger.debug("{}: {}".format(r.status_code, r.content))
+        return r
+
+    def _get_trusted_identities_json(self, get_trusted: dict) -> Response:
+        logger.debug("trust an identity [json]: {}".format(get_trusted))
+        r = requests.get(self.get_url(KEY_SERVICE) + '/pubkey/trusted', json=get_trusted,
+                          headers=self._auth)
+        logger.debug("{}: {}".format(r.status_code, r.content))
+        return r
+
     def _deregister_identity_json(self, key_deregistration: dict) -> Response:
-        logger.debug("de-register device identity [json]: {}".format(key_deregistration))
+        logger.debug("de-register identity [json]: {}".format(key_deregistration))
         r = requests.delete(self.get_url(KEY_SERVICE) + '/pubkey', json=key_deregistration,
                             headers=self._auth)
         logger.debug("{}: {}".format(r.status_code, r.content))


### PR DESCRIPTION
This is the first version of the web-of-trust demo. `key-service` REST calls that have been missing before have been added on the same branch.

What the demo does and how to call has been documented in the `Example: Web-of-Trust` section in `README.md`. The expected results mentioned there describe how the `key-service` will behave in the near future. Currently it only searches for trusted keys with a depth of 1.
This will change with UP-254.