### PR TITLE
Made `_sign` and `_verify` symmetric

### DIFF
--- a/examples/test-verification.py
+++ b/examples/test-verification.py
@@ -1,4 +1,3 @@
-import hashlib
 from uuid import UUID
 
 from ed25519 import VerifyingKey
@@ -15,8 +14,7 @@ keystore.insert_ed25519_verifying_key(remote_uuid, remote_vk)
 
 class ProtocolImpl(ubirch.Protocol):
     def _verify(self, uuid: UUID, message: bytes, signature: bytes) -> dict:
-        hash = hashlib.sha512(message).digest()
-        return keystore.find_verifying_key(uuid).verify(signature, hash)
+        return keystore.find_verifying_key(uuid).verify(signature, message)
 
 
 proto = ProtocolImpl(SIGNED)

--- a/tests/test_ubirch_protocol.py
+++ b/tests/test_ubirch_protocol.py
@@ -17,13 +17,11 @@
 # limitations under the License.
 
 import binascii
-import hashlib
 import logging
 import unittest
 from uuid import UUID
 
 import ed25519
-import pytest
 
 import ubirch
 from ubirch.ubirch_protocol import SIGNED, CHAINED
@@ -73,7 +71,7 @@ class Protocol(ubirch.Protocol):
         return self.sk.sign(message)
 
     def _verify(self, uuid: UUID, message: bytes, signature: bytes) -> bytes:
-        return self.vk.verify(signature, hashlib.sha512(message).digest())
+        return self.vk.verify(signature, message)
 
 
 class TestUbirchProtocol(unittest.TestCase):


### PR DESCRIPTION
`_verify` implementations don't have to explicitly hash the message any more.

All tests pass. 
We probably should do a version bump, as that's not compatible with old `Protocol` implementations.