### PR TITLE
Backend key test review

### DIFF
--- a/examples/UbirchWrapper.py
+++ b/examples/UbirchWrapper.py
@@ -6,9 +6,6 @@ from requests import codes, Response
 import ubirch
 from ubirch.ubirch_protocol import UNPACKED_UPP_FIELD_PREV_SIG, UBIRCH_PROTOCOL_TYPE_REG, UBIRCH_PROTOCOL_TYPE_BIN
 
-# from ubirch_keys_and_uuids import UBIRCH_UUIDS, UBIRCH_PUBKEYS_EC, UBIRCH_PUBKEYS_ED
-# from ubirch.ubirch_backend_keys import *
-
 ECDSA_TYPE = "ecdsa"
 EDDSA_TYPE = "ed25519"
 

--- a/examples/UbirchWrapper.py
+++ b/examples/UbirchWrapper.py
@@ -56,7 +56,7 @@ class Proto(ubirch.Protocol):
         if env not in ubirch.get_backend_environments():
             raise ValueError("Invalid ubirch env! Must be one of {}".format(ubirch.get_backend_environments()))
 
-        # check if the keystore has the same key_type for the device UUID and the backend response
+        # insert key for backend response signature verification into keystore
         if key_type == ECDSA_TYPE:
             self.__ks.insert_ecdsa_verifying_key(ubirch.get_backend_uuid(env),
                                                  ubirch.get_backend_verifying_key(env, ECDSA_TYPE))

--- a/examples/UbirchWrapper.py
+++ b/examples/UbirchWrapper.py
@@ -54,7 +54,7 @@ class Proto(ubirch.Protocol):
 
         # check env
         if env not in ubirch.getBackendEnvironemts():
-            raise ValueError("Invalid ubirch env! Must be one of {}".format(list(ubirch.getBackendEnvironemts())))
+            raise ValueError("Invalid ubirch env! Must be one of {}".format(ubirch.getBackendEnvironemts()))
 
         # check if the keystore has the same key_type for the device UUID and the backend response
         if key_type == ECDSA_TYPE:

--- a/examples/UbirchWrapper.py
+++ b/examples/UbirchWrapper.py
@@ -53,22 +53,22 @@ class Proto(ubirch.Protocol):
                 raise ValueError(f"existing key for {uuid} is not from expected type {key_type}")
 
         # check env
-        if env not in ubirch.getBackendEnvironemts():
-            raise ValueError("Invalid ubirch env! Must be one of {}".format(ubirch.getBackendEnvironemts()))
+        if env not in ubirch.get_backend_environments():
+            raise ValueError("Invalid ubirch env! Must be one of {}".format(ubirch.get_backend_environments()))
 
         # check if the keystore has the same key_type for the device UUID and the backend response
         if key_type == ECDSA_TYPE:
-            if self.__ks._ks.entries.get(ubirch.getBackendUuid(env).hex, None) != None:
+            if self.__ks._ks.entries.get(ubirch.get_backend_uuid(env).hex, None) != None:
                 # suffix-less pubkey found, delete it
-                self.__ks._ks.entries.pop(ubirch.getBackendUuid(env).hex)
+                self.__ks._ks.entries.pop(ubirch.get_backend_uuid(env).hex)
 
-            self.__ks.insert_ecdsa_verifying_key(ubirch.getBackendUuid(env), ubirch.getBackendKeys(env,ECDSA_TYPE))
+            self.__ks.insert_ecdsa_verifying_key(ubirch.get_backend_uuid(env), ubirch.get_backend_verifying_key(env, ECDSA_TYPE))
         elif key_type == EDDSA_TYPE:
-            if self.__ks._ks.entries.get(ubirch.getBackendUuid(env).hex + '_ecd', None) != None:
+            if self.__ks._ks.entries.get(ubirch.get_backend_uuid(env).hex + '_ecd', None) != None:
                 # suffix-less pubkey found, delete it
-                self.__ks._ks.entries.pop(ubirch.getBackendUuid(env).hex + '_ecd')
+                self.__ks._ks.entries.pop(ubirch.get_backend_uuid(env).hex + '_ecd')
 
-            self.__ks.insert_ed25519_verifying_key(ubirch.getBackendUuid(env), ubirch.getBackendKeys(env,EDDSA_TYPE))
+            self.__ks.insert_ed25519_verifying_key(ubirch.get_backend_uuid(env), ubirch.get_backend_verifying_key(env, EDDSA_TYPE))
 
         # load last signature for device
         self.load(uuid)
@@ -80,7 +80,6 @@ class Proto(ubirch.Protocol):
         with open(uuid.hex + ".sig", "wb") as f:
             pickle.dump(signatures, f)
 
-    #===== The functions below are called from inside ubirch.Protocol ====#
     def load(self, uuid: UUID):
         try:
             with open(uuid.hex + ".sig", "rb") as f:
@@ -91,6 +90,7 @@ class Proto(ubirch.Protocol):
             logger.warning("no existing saved signatures")
             pass
 
+    #===== The functions below are called from inside ubirch.Protocol ====#
     def _sign(self, uuid: UUID, message: bytes) -> bytes:
         signing_key = self.__ks.find_signing_key(uuid)
 
@@ -225,7 +225,7 @@ class UbirchWrapper:
 
     def verifyResponseSender(self, response: Response):
         """! Verify that the response came from the backend """
-        if self.protocol.verify_signature(ubirch.getBackendUuid(self.env), response.content) == True:
+        if self.protocol.verify_signature(ubirch.get_backend_uuid(self.env), response.content):
             logger.info("Backend response signature successfully verified!")
         else:
             logger.error("Backend response signature verification FAILED!")

--- a/examples/UbirchWrapper.py
+++ b/examples/UbirchWrapper.py
@@ -58,17 +58,11 @@ class Proto(ubirch.Protocol):
 
         # check if the keystore has the same key_type for the device UUID and the backend response
         if key_type == ECDSA_TYPE:
-            if self.__ks._ks.entries.get(ubirch.get_backend_uuid(env).hex, None) != None:
-                # suffix-less pubkey found, delete it
-                self.__ks._ks.entries.pop(ubirch.get_backend_uuid(env).hex)
-
-            self.__ks.insert_ecdsa_verifying_key(ubirch.get_backend_uuid(env), ubirch.get_backend_verifying_key(env, ECDSA_TYPE))
+            self.__ks.insert_ecdsa_verifying_key(ubirch.get_backend_uuid(env),
+                                                 ubirch.get_backend_verifying_key(env, ECDSA_TYPE))
         elif key_type == EDDSA_TYPE:
-            if self.__ks._ks.entries.get(ubirch.get_backend_uuid(env).hex + '_ecd', None) != None:
-                # suffix-less pubkey found, delete it
-                self.__ks._ks.entries.pop(ubirch.get_backend_uuid(env).hex + '_ecd')
-
-            self.__ks.insert_ed25519_verifying_key(ubirch.get_backend_uuid(env), ubirch.get_backend_verifying_key(env, EDDSA_TYPE))
+            self.__ks.insert_ed25519_verifying_key(ubirch.get_backend_uuid(env),
+                                                   ubirch.get_backend_verifying_key(env, EDDSA_TYPE))
 
         # load last signature for device
         self.load(uuid)

--- a/ubirch/__init__.py
+++ b/ubirch/__init__.py
@@ -17,4 +17,4 @@
 from .ubirch_ks import KeyStore
 from .ubirch_protocol import Protocol
 from .ubirch_api import API
-from .ubirch_backend_keys import getBackendKeys, getBackendUuid, getBackendEnvironemts
+from .ubirch_backend_keys import get_backend_verifying_key, get_backend_uuid, get_backend_environments

--- a/ubirch/ubirch_backend_keys.py
+++ b/ubirch/ubirch_backend_keys.py
@@ -29,7 +29,7 @@ KEYS = {
     "dev":{
         "uuid":"9d3c78ff-22f3-4441-a5d1-85c636d486ff",
         "vk":{
-            "ed25519":"39ff77632b034d0eba6d219c2ff192e9f24916c9a02672acb49fd05118aad251",
+            "ed25519":"a2403b92bc9add365b3cd12ff120d020647f84ea6983f98bc4c87e0f4be8cd66",
             "ecdsa":"2e753c064bc671940fcb98165542fe3c70340cff5d53ad47f0304ef2166f4f223b9572251b5fe8aee54c4fb812da79590caf501beba0911b7fcd3add2eb0180c"    
         }
     },

--- a/ubirch/ubirch_backend_keys.py
+++ b/ubirch/ubirch_backend_keys.py
@@ -1,6 +1,6 @@
 
 ##
-# @file ubirch_backen_keys.py
+# @file ubirch_backend_keys.py
 # ubirch backend keys getter functions
 #
 # @author Waldemar Gruenwald

--- a/ubirch/ubirch_backend_keys.py
+++ b/ubirch/ubirch_backend_keys.py
@@ -49,14 +49,14 @@ KEYS = {
     }
 }
 
-def getBackendEnvironemts() -> list:
+def get_backend_environments() -> list:
     """!
     Getter to list the available backend environments.
     @return available Environments
     """
     return list(KEYS.keys())
 
-def getBackendUuid(env: str = "demo") -> UUID:
+def get_backend_uuid(env: str = "demo") -> UUID:
     """!
     Getter function for environment (`env`) specific backend UUID
     @param env Environment of the backend, can be `"dev"`, `"demo"`, or `"prod"`. Default is `"demo"`
@@ -64,7 +64,7 @@ def getBackendUuid(env: str = "demo") -> UUID:
     """
     return UUID(hex=KEYS[env]["uuid"])
 
-def getBackendKeys(env: str = "demo", key_type: str = EDDSA_TYPE) -> ed25519.VerifyingKey or ecdsa.VerifyingKey:
+def get_backend_verifying_key(env: str = "demo", key_type: str = EDDSA_TYPE) -> ed25519.VerifyingKey or ecdsa.VerifyingKey:
     """!
     Getter function for environment (`env`) specific backend verification key
     @param env Environment of the backend, can be `"dev"`, `"demo"`, or `"prod"`. Default is `"demo"`

--- a/ubirch/ubirch_backend_keys.py
+++ b/ubirch/ubirch_backend_keys.py
@@ -54,7 +54,7 @@ def getBackendEnvironemts() -> list:
     Getter to list the available backend environments.
     @return available Environments
     """
-    return KEYS.keys()
+    return list(KEYS.keys())
 
 def getBackendUuid(env: str = "demo") -> UUID:
     """!


### PR DESCRIPTION
**Fixed:**

- follow PEP8 conventions
  - [rename function names to comply with pep8 naming conventions](https://github.com/ubirch/ubirch-protocol-python/commit/8105c79058fbf8839d31e4c1cd3915ad49d694f9)
- some minor fixes
  - [convert getBackendEnvironemts return type to list](https://github.com/ubirch/ubirch-protocol-python/commit/c67e14e86409ed04511d2a2b3c16a6b8d97851bf)
  - [fix typo](https://github.com/ubirch/ubirch-protocol-python/commit/6ab851f97cf9016f390b4a2df03fb36caa721b28)
  - [fix dev ed25519 backend public key](https://github.com/ubirch/ubirch-protocol-python/commit/3915e88818e08dc07d259c3309d20e8c715d8c86)
  - [fix comment](https://github.com/ubirch/ubirch-protocol-python/commit/f2ace1e3db5f2f1856e9507d8b7465ffedd5fd8e)
- cleanup
  - [remove deletion of unused backend response verification keys from keystore in Proto constructor as it unnecessarily crowds the code and decreases readability](https://github.com/ubirch/ubirch-protocol-python/commit/1f42891f245e495e81e45341200ce62c9e4e36d2) 
  - [remove unused imports](https://github.com/ubirch/ubirch-protocol-python/commit/b77b2372019ff96f529e869d4722bbef13ed3b98)

